### PR TITLE
Update Shortcode.js

### DIFF
--- a/src/Shortcode.js
+++ b/src/Shortcode.js
@@ -82,7 +82,7 @@ Shortcode.prototype.convertMatchesToNodes = function() {
 
 Shortcode.prototype.replaceNodes = function() {
   var self = this, html, match, result, done, node, fn, replacer,
-      nodes = document.querySelectorAll('.sc-node');
+      nodes = this.el.querySelectorAll('.sc-node');
 
   replacer = function(result) {
     if (result.jquery) { result = result[0]; }
@@ -93,7 +93,7 @@ Shortcode.prototype.replaceNodes = function() {
 
   for (var i = 0, len = this.matches.length; i < len; i++) {
     match = this.matches[i];
-    node  = document.querySelector('.sc-node-' + match.name);
+    node  = this.el.querySelector('.sc-node-' + match.name);
 
     if (node && node.dataset.scTag === match.tag) {
       fn     = this.tags[match.name].bind(match);


### PR DESCRIPTION
update replaceNodes to query this.el and not document.

reason:

```
var el = document.createElement('span');
el.innerHTML = '[hello]Good Morning World[/hello]';

new Shortcode(el, {
  hello: function() {
    return this.content;
  }
});
```

The above will not work if replaceNodes function queries document when parsing.
