### PR TITLE
Proposed fix for escapeTagRegExp does not escape all possible problematic characters

### DIFF
--- a/src/Shortcode.js
+++ b/src/Shortcode.js
@@ -165,7 +165,7 @@ Shortcode.prototype.parseOptions = function(stringOptions) {
 };
 
 Shortcode.prototype.escapeTagRegExp = function(regex) {
-  return regex.replace(/[\[\]\/]/g, '\\$&');
+  return regex.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
 };
 
 Shortcode.prototype.template = function(s, d) {


### PR DESCRIPTION
Hey there,

I ran into an issue where question marks in attribute values were causing a failure to parse shortcodes that contained them, e.g. 

[mytag myattribute="What?"]

I traced this down to escapeTagRegExp failing to escape the question marks, so I added additional regex string escape characters as per https://stackoverflow.com/a/6969486.

Hope this helps, and thanks for shortcode.js !